### PR TITLE
Select RUNNING instances only, fix persistent label check, make email conditional

### DIFF
--- a/problem1.py
+++ b/problem1.py
@@ -39,7 +39,7 @@ def main():
     for zonepath , result in instances['items'].items():
         if 'instances' in result:
             for instance in result['instances']:
-                if instance.get('labels', {} ).get('persistent', 'false') == 'false':
+                if instance.get('labels', {} ).get('persistent', 'false') != 'true' and instance['status'] == 'RUNNING':
                     zone = zonepath.split('/')[1]
                     stopRes = stopInstance( instance['name'] , compute , projId , zone )
                     warnings +=  [ (instance['name'] , w ) for w in stopRes.get( 'warnings' , [] )]
@@ -47,15 +47,8 @@ def main():
                     if 'error' not in instance:
                         stopped.append(instance['name'])
 
-    notify( '''
-Stopped instances:
-{}
-Warnings:
-{}
-Errors:
-{}
-'''.format(*map(json.dumps, [stopped, warnings, errors])))
-    
+    if stopped or warnings or errors:
+        notify('\nStopped instances:\n{}Warnings:\n{}\nErrors:\n{}\n'.format(*map(json.dumps, [stopped, warnings, errors])))
     
     
 if __name__ == "__main__":


### PR DESCRIPTION
There are a few small problems in your submission. 

- When you get a list of instances, you need to make sure that the instances that you are trying to stop are in the `RUNNING` status. Your script currently does not filter instances by their status.  This is not really a problem if you only have a few instances, but in a larger deployments, when there might be thousands of instances, you definitely want to filter your results.

- When you check if a in instance needs to be omitted based on the `persistent` label, you are doing a check that only works if there are no labels defined, the instances does not have the `persistent` label, or if the instance is explicitly marked with `false`.  If an instance is marked with the label `persistent:foo` it will be omitted, and you definitely do not want that.  A better approach is to check for `persistent` not equal to "true".
- The other thing, which is not included in this PR (since it is not part of the repo) but needs to be corrected is your requirements file (googleapiclient is not a package that can be installed with `pip`)

I also added a condition to only send the notification if there are instances that the script tried to stop
